### PR TITLE
Add commit ID to shadps4 git source to supplement tag

### DIFF
--- a/net.shadps4.shadPS4.yaml
+++ b/net.shadps4.shadPS4.yaml
@@ -80,6 +80,7 @@ modules:
       - type: git
         url: https://github.com/shadps4-emu/shadPS4
         tag: v.0.5.0
+        commit: a1a98966eee07e7ecf3a5e3836b5f2ecde5664b0
         x-checker-data:
           type: json
           url: https://api.github.com/repos/shadps4-emu/shadps4/releases/latest


### PR DESCRIPTION
This will fix the external data checker reporting there's an update when there isn't - tags can theoretically move to different commits so adding the tag+commit makes sure the build is reproducible.