### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+ * @georgemoralis @ngoquang2708 @fpiesche @jardon


### PR DESCRIPTION
This will automatically add all of us as code reviewers to any PRs created by the flathub update mechanism.
